### PR TITLE
Hide the "Partners by country" breakdown from the dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,10 +257,11 @@ document.querySelectorAll('.nav-item').forEach(tab => {
   const recPct = (fb.recommend && fb.recommend.pct != null) ? fb.recommend.pct + '%' : '—';
   const keepPct = (fb.keep && fb.keep.pct != null) ? fb.keep.pct + '%' : '—';
   const impact = (fb.ratings && fb.ratings.impact) || {};
-  // Partner institutions: the per-country breakdown and the map come from the
-  // same confirmed set, so the two always agree. `partnerCount` is still derived
-  // from the live data but is intentionally not shown as a card — restoring the
-  // card is a one-line change.
+  // Partner institutions: the count, the per-country breakdown and the map all
+  // come from the same confirmed set, so they always agree. `partnerCount` and
+  // `countryRows` are still derived from the live data but are intentionally not
+  // rendered — restoring either one is a one-line change. `instCountries` is
+  // still live either way: the Countries card counts it (see `countryCount`).
   const partnerCount = g.partnerInstitutions || 0;
   const instCountries = g.instCountries || {};
   const countryRows = Object.entries(instCountries)
@@ -293,7 +294,6 @@ document.querySelectorAll('.nav-item').forEach(tab => {
       <div style="position:relative;height:260px"><canvas id="instGrowthChart"></canvas></div>
     </div>
     <div class="chart-container"><h3>Where our partners are</h3><div class="chart-sub">Partner institutions around the world</div><div id="instMap"></div></div>
-    <div class="chart-container"><h3>Partners by country</h3><div class="chart-sub">Confirmed partner institutions in each country</div><div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:2px 32px">${countryRows}</div></div>
     <div class="chart-container"><h3>Who's joined us</h3><div class="chart-sub">The academic backgrounds students bring</div><div id="fosChart"></div></div>
 
     <div class="act-label act-skills">Skills unlocked</div>

--- a/scripts/template.html
+++ b/scripts/template.html
@@ -257,10 +257,11 @@ document.querySelectorAll('.nav-item').forEach(tab => {
   const recPct = (fb.recommend && fb.recommend.pct != null) ? fb.recommend.pct + '%' : '—';
   const keepPct = (fb.keep && fb.keep.pct != null) ? fb.keep.pct + '%' : '—';
   const impact = (fb.ratings && fb.ratings.impact) || {};
-  // Partner institutions: the per-country breakdown and the map come from the
-  // same confirmed set, so the two always agree. `partnerCount` is still derived
-  // from the live data but is intentionally not shown as a card — restoring the
-  // card is a one-line change.
+  // Partner institutions: the count, the per-country breakdown and the map all
+  // come from the same confirmed set, so they always agree. `partnerCount` and
+  // `countryRows` are still derived from the live data but are intentionally not
+  // rendered — restoring either one is a one-line change. `instCountries` is
+  // still live either way: the Countries card counts it (see `countryCount`).
   const partnerCount = g.partnerInstitutions || 0;
   const instCountries = g.instCountries || {};
   const countryRows = Object.entries(instCountries)
@@ -293,7 +294,6 @@ document.querySelectorAll('.nav-item').forEach(tab => {
       <div style="position:relative;height:260px"><canvas id="instGrowthChart"></canvas></div>
     </div>
     <div class="chart-container"><h3>Where our partners are</h3><div class="chart-sub">Partner institutions around the world</div><div id="instMap"></div></div>
-    <div class="chart-container"><h3>Partners by country</h3><div class="chart-sub">Confirmed partner institutions in each country</div><div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:2px 32px">${countryRows}</div></div>
     <div class="chart-container"><h3>Who's joined us</h3><div class="chart-sub">The academic backgrounds students bring</div><div id="fosChart"></div></div>
 
     <div class="act-label act-skills">Skills unlocked</div>


### PR DESCRIPTION
## What this does

Removes the **Partners by country** section from the [dashboard](https://wordpress.github.io/WPCredits/) — the per-country list of confirmed partner institutions (Spain 12, India 5, …) that sat below the map in Scale & momentum.

Follow-up to #184, which hid the *Students currently in the program* and *Partner institutions* cards.

Scale & momentum now reads:

| | |
|---|---|
| Cards | Students who have joined to date · Graduates to date · Countries |
| Charts | How the program is growing · How our partner network is growing |
| Map | Where our partners are |
| Then | Who's joined us |

## The data keeps flowing in the background

Display-only, as with #184. `countryRows` is still built from the live `instCountries` on every render — sorted, formatted, ready — it is simply no longer inserted into the page. Restoring the section is a one-line change.

`instCountries` is doubly live: `countryCount` still counts it for the **Countries** card, which is unchanged at 17.

The partner growth chart and the map are **deliberately left as they are** — only the per-country list is gone.

## Notes

Applied identically to `scripts/template.html` (the source) and `index.html` (the generated copy GitHub Pages serves). Worth noting that the `Update dashboard data 2026-09-07` rebuild that landed on `trunk` right after #184 merged regenerated `index.html` and kept the hidden cards hidden — so the template edit is doing its job across rebuilds.

Verified by rendering the local `index.html` with its real data blob: the per-country list is gone, the map and both charts are intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)